### PR TITLE
Do not append to cached bar files

### DIFF
--- a/data_processor/base_bars.py
+++ b/data_processor/base_bars.py
@@ -28,7 +28,7 @@ class BaseBars:
             full_bars.columns = cols
             #print(type(list_bars[2][3]))
             #list_bars.columns = cols
-            full_bars.to_csv(self.output_path, header=header, index=False, mode='a')
+            full_bars.to_csv(self.output_path, header=header, index=False)
             header = False
 
     


### PR DESCRIPTION
This will make headers recognized as data by pandoc in the next read.

Closes #23.